### PR TITLE
Add rails gem to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ Run Chrome with the flag and open `demo/index.html` to see it in action.
 
 * Angular component by [@livingobjects](https://github.com/livingobjects): https://github.com/livingobjects/angular-memory-stats
 * Ember addon by [@stefanpenner](https://github.com/stefanpenner): https://github.com/stefanpenner/ember-browser-stats
+* Rails gem by [@jurre](https://github.com/jurre):
+https://github.com/jurre/memory-stats-js-rails


### PR DESCRIPTION
I've added the MIT license to the gem since that's what @stefanpenner had in his Ember addon (and it's what's generated automatically). I hope that's okay, please let me know if it's not, and I'd be glad to update it!