### PR TITLE
Fix spelling mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Like [stats.js](https://github.com/mrdoob/stats.js/) but for JS memory
 1. Start Chrome [with](http://www.chromium.org/developers/how-tos/run-chromium-with-flags) `--enable-precise-memory-info`
     - Otherwise the results from performance.memory are bucketed and less useful.
 1. Include memory.stats.js
-1. Instatiate it (`stats = new MemoryStats()`, add the `stats.element` to the DOM, and run `stats.update()` regularly.
+1. Instantiate it (`stats = new MemoryStats()`, add the `stats.element` to the DOM, and run `stats.update()` regularly.
 
 That might look something like:
 


### PR DESCRIPTION
Only made 1 minor fix:
1) Fixed spelling mistake with 'instantiate' (line 14)

No other changes were made.
