### PR TITLE
Added bookmarklet for embedding on any page

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ https://github.com/jurre/memory-stats-js-rails
 You can add this code to any page using the following bookmarklet:
 
 ```js
-javascript:(function(){var script=document.createElement('script');script.src='https://cdn.rawgit.com/omahlama/memory-stats.js/ad4b94c8bcd6a6415c51a8e4b1bf1ff4281ba5d1/bookmarklet.js';document.getElementsByTagName('head')[0].appendChild(script);})()
+javascript:(function(){var script=document.createElement('script');script.src='https://cdn.rawgit.com/omahlama/memory-stats.js/2214d50228c1b4af5d5c03ba1d7f69649aa461a6/bookmarklet.js';document.getElementsByTagName('head')[0].appendChild(script);})()
 ```

--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ https://github.com/jurre/memory-stats-js-rails
 You can add this code to any page using the following bookmarklet:
 
 ```js
-javascript:(function(){var script=document.createElement('script');script.src='https://cdn.rawgit.com/omahlama/memory-stats.js/2214d50228c1b4af5d5c03ba1d7f69649aa461a6/bookmarklet.js';document.getElementsByTagName('head')[0].appendChild(script);})()
+javascript:(function(){var script=document.createElement('script');script.src='https://rawgit.com/paulirish/memory-stats.js/master/bookmarklet.js';document.getElementsByTagName('head')[0].appendChild(script);})()
 ```

--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ https://github.com/jurre/memory-stats-js-rails
 You can add this code to any page using the following bookmarklet:
 
 ```js
-javascript:(function(){var script=document.createElement('script');script.src='https://rawgit.com/paulirish/memory-stats.js/master/bookmarklet.js';document.getElementsByTagName('head')[0].appendChild(script);})()
+javascript:(function(){var script=document.createElement('script');script.src='https://rawgit.com/paulirish/memory-stats.js/master/bookmarklet.js';document.head.appendChild(script);})()
 ```

--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ Run Chrome with the flag and open `demo/index.html` to see it in action.
 * Ember addon by [@stefanpenner](https://github.com/stefanpenner): https://github.com/stefanpenner/ember-browser-stats
 * Rails gem by [@jurre](https://github.com/jurre):
 https://github.com/jurre/memory-stats-js-rails
+
+# Bookmarklet
+
+You can add this code to any page using the following bookmarklet:
+
+```js
+javascript:(function(){var script=document.createElement('script');script.src='https://cdn.rawgit.com/omahlama/memory-stats.js/ad4b94c8bcd6a6415c51a8e4b1bf1ff4281ba5d1/bookmarklet.js';document.getElementsByTagName('head')[0].appendChild(script);})()
+```

--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -1,0 +1,18 @@
+var module;
+var script = document.createElement('script');
+script.onload = function() {
+  var stats = new MemoryStats();
+
+    stats.domElement.style.position = 'fixed';
+    stats.domElement.style.right        = '0px';
+    stats.domElement.style.bottom       = '0px';
+
+    document.body.appendChild( stats.domElement );
+
+    requestAnimationFrame(function rAFloop(){
+        stats.update();
+        requestAnimationFrame(rAFloop);
+    });
+};
+script.src = "https://rawgit.com/paulirish/memory-stats.js/master/memory-stats.js";
+document.getElementsByTagName('head')[0].appendChild(script);

--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -14,5 +14,5 @@ script.onload = function() {
         requestAnimationFrame(rAFloop);
     });
 };
-script.src = "https://rawgit.com/paulirish/memory-stats.js/master/memory-stats.js";
+script.src = "https://cdn.rawgit.com/paulirish/memory-stats.js/b2fde44a6279d72dd272c04a01d1f67327906188/memory-stats.js";
 document.getElementsByTagName('head')[0].appendChild(script);

--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -1,5 +1,4 @@
 (function() {
-	var module;
 	var script = document.createElement('script');
 	script.onload = function() {
 	  var stats = new MemoryStats();
@@ -16,5 +15,5 @@
 	    });
 	};
 	script.src = "https://rawgit.com/paulirish/memory-stats.js/master/memory-stats.js";
-	document.getElementsByTagName('head')[0].appendChild(script);
+	document.head.appendChild(script);
 }})();

--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -1,18 +1,20 @@
-var module;
-var script = document.createElement('script');
-script.onload = function() {
-  var stats = new MemoryStats();
+(function() {
+	var module;
+	var script = document.createElement('script');
+	script.onload = function() {
+	  var stats = new MemoryStats();
 
-    stats.domElement.style.position = 'fixed';
-    stats.domElement.style.right        = '0px';
-    stats.domElement.style.bottom       = '0px';
+	    stats.domElement.style.position = 'fixed';
+	    stats.domElement.style.right        = '0px';
+	    stats.domElement.style.bottom       = '0px';
 
-    document.body.appendChild( stats.domElement );
+	    document.body.appendChild( stats.domElement );
 
-    requestAnimationFrame(function rAFloop(){
-        stats.update();
-        requestAnimationFrame(rAFloop);
-    });
-};
-script.src = "https://cdn.rawgit.com/paulirish/memory-stats.js/b2fde44a6279d72dd272c04a01d1f67327906188/memory-stats.js";
-document.getElementsByTagName('head')[0].appendChild(script);
+	    requestAnimationFrame(function rAFloop(){
+	        stats.update();
+	        requestAnimationFrame(rAFloop);
+	    });
+	};
+	script.src = "https://rawgit.com/paulirish/memory-stats.js/master/memory-stats.js";
+	document.getElementsByTagName('head')[0].appendChild(script);
+}})();


### PR DESCRIPTION
This bookmarklet is maintainable, because it just loads the script from github. You will have to update the commit link when you make modifications to `bookmarklet.js`, but you can safely ignore this feature when modifying the actual script.

Because the bookmarklet uses rawgit.com, you will have to change the url to point to the correct, non-forked repo after merging in master. Steps to do that:
* Go to the newest commit id in github, browse files and go to bookmarklet.js page
* Copy the url to http://rawgit.com -> you get the rawgit url. Use the production one.
* Change the bookmarklet url in README.md to point to the new rawgit url.

The reason that we need a commit id url (copied from rawgit.com): "It's best to use a specific tag or commit hash in the URL (not a branch). Files are cached permanently after the first request"