### PR TITLE
Remove extra } in bookmarklet.js

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -16,4 +16,4 @@
 	};
 	script.src = "https://rawgit.com/paulirish/memory-stats.js/master/memory-stats.js";
 	document.head.appendChild(script);
-}})();
+})();


### PR DESCRIPTION
There's an extra } at the end of bookmarklet.js.