### PR TITLE
adding a z-index on the stats element

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -16,4 +16,4 @@
 	};
 	script.src = "https://rawgit.com/paulirish/memory-stats.js/master/memory-stats.js";
 	document.head.appendChild(script);
-}})();
+})();

--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -6,6 +6,7 @@
 	    stats.domElement.style.position = 'fixed';
 	    stats.domElement.style.right        = '0px';
 	    stats.domElement.style.bottom       = '0px';
+	    stats.domElement.style.zIndex       = '1000';
 
 	    document.body.appendChild( stats.domElement );
 


### PR DESCRIPTION
The stats element stays hidden on pages with heavy z-index layering.
Also removed the extra }.