### PR TITLE
fixed unsupported detection for Firefox

### DIFF
--- a/memory-stats.js
+++ b/memory-stats.js
@@ -46,7 +46,7 @@ var MemoryStats = function (){
 
 	// polyfill usedJSHeapSize
 	if (window.performance && !performance.memory){
-		performance.memory = { usedJSHeapSize : 0 };
+		performance.memory = { usedJSHeapSize : 0, totalJSHeapSize : 0 };
 	}
 
 	// support of the API?


### PR DESCRIPTION
The detection didn't work for browsers without performance.memory.