### PR TITLE
Added the scale on 30MB step ability

### DIFF
--- a/memory-stats.js
+++ b/memory-stats.js
@@ -7,9 +7,8 @@ var MemoryStats = function (){
 
 	var msMin	= 100;
 	var msMax	= 0;
-	var redrawMBThreshold = 30;
-	var redrawMBStep = 30;
 	var GRAPH_HEIGHT = 30;
+	var redrawMBThreshold = GRAPH_HEIGHT;
 
 	var container	= document.createElement( 'div' );
 	container.id	= 'stats';
@@ -95,13 +94,13 @@ var MemoryStats = function (){
 			var mbValue	= ms / (1024*1024);
 			
 			if(mbValue > redrawMBThreshold) {
-				var factor = (mbValue - (mbValue % redrawMBStep))/ redrawMBStep;
-				var newThreshold = redrawMBStep * (factor + 1);
-				redrawGraph(msGraph, redrawMBStep/redrawMBThreshold, redrawMBStep/newThreshold);
+				var factor = (mbValue - (mbValue % GRAPH_HEIGHT))/ GRAPH_HEIGHT;
+				var newThreshold = GRAPH_HEIGHT * (factor + 1);
+				redrawGraph(msGraph, GRAPH_HEIGHT/redrawMBThreshold, GRAPH_HEIGHT/newThreshold);
 				redrawMBThreshold = newThreshold;
 			}
 
-			updateGraph( msGraph, GRAPH_HEIGHT-mbValue*(redrawMBStep/redrawMBThreshold), color);
+			updateGraph( msGraph, GRAPH_HEIGHT-mbValue*(GRAPH_HEIGHT/redrawMBThreshold), color);
 
 			function bytesToSize( bytes, nFractDigit ){
 				var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];

--- a/memory-stats.js
+++ b/memory-stats.js
@@ -33,7 +33,7 @@ var MemoryStats = function (){
 	while ( msGraph.children.length < 74 ) {
 
 		var bar = document.createElement( 'span' );
-		bar.style.cssText = 'width:1px;height:30px;float:left;background-color:#131';
+		bar.style.cssText = 'width:1px;height:' + GRAPH_HEIGHT + 'px;float:left;background-color:#131';
 		msGraph.appendChild( bar );
 
 	}


### PR DESCRIPTION
Graph will now redraw when a 30MB threshold is hit and apply the new
scale to following draws. I also cleaned up a bit of code and defined the graph
height as a “constant”.

Before crossing initial 30MB limit:

![screen shot 2015-02-22 at 1 48 34 pm](https://cloud.githubusercontent.com/assets/2173532/6320676/88f612ac-ba99-11e4-8154-f7db27f00e93.png)

After crossing initial 30MB limit (use red line as reference):

![screen shot 2015-02-22 at 1 48 41 pm](https://cloud.githubusercontent.com/assets/2173532/6320678/94364a60-ba99-11e4-8f97-5ad8a7080db3.png)

Note: This rescaling happens on any threshold step, not just the initial.